### PR TITLE
Put VO translatable field to NULL when DB value is not set (or equals 0)

### DIFF
--- a/src/Berthe/DAL/AbstractReader.php
+++ b/src/Berthe/DAL/AbstractReader.php
@@ -130,12 +130,16 @@ abstract class AbstractReader implements Reader {
         foreach($datas as $rownum => $row) {
             foreach($translatableFields as $translatableField) {
                 if (array_key_exists($translatableField, $row)) {
-                    $translationIdsToFetch[] = $row[$translatableField];
+                    if ($row[$translatableField]) {
+                        $translationIdsToFetch[] = $row[$translatableField];
 
-                    if (!array_key_exists($row[$translatableField], $translationIdsMapping)) {
-                        $translationIdsMapping[$row[$translatableField]] = array();
+                        if (!array_key_exists($row[$translatableField], $translationIdsMapping)) {
+                            $translationIdsMapping[$row[$translatableField]] = array();
+                        }
+                        $translationIdsMapping[$row[$translatableField]][] = array('rownum' => $rownum, 'field' => $translatableField);
+                    } else {
+                        $datas[$rownum][$translatableField] = null;
                     }
-                    $translationIdsMapping[$row[$translatableField]][] = array('rownum' => $rownum, 'field' => $translatableField);
                 }
             }
         }


### PR DESCRIPTION
Je sais que ça ne devrait pas vraiment arriver, mais en base on a pas mal de champs "translatable" dont la valeur est à zéro.
Du coup, la propriété de l'objet vaut également zéro, alors que c'est une propriété de type Translation, elle devrait être à NULL quand il n'y a pas de traduction.

Typiquement, ça nous pose des problèmes par exemple dans API quand on expose un champ translation (__toArray sur un int, ça march moyen)