### PR TITLE
Implementing soft delete

### DIFF
--- a/src/Berthe/DAL/AbstractReader.php
+++ b/src/Berthe/DAL/AbstractReader.php
@@ -2,6 +2,8 @@
 
 namespace Berthe\DAL;
 
+use InvalidArgumentException;
+
 abstract class AbstractReader implements Reader {
     /**
      * Class name of the VO for current package

--- a/src/Berthe/DAL/AbstractWriter.php
+++ b/src/Berthe/DAL/AbstractWriter.php
@@ -2,6 +2,8 @@
 
 namespace Berthe\DAL;
 
+use InvalidArgumentException;
+
 abstract class AbstractWriter implements Writer
 {
 


### PR DESCRIPTION
Soft delete can now be activated for reader and writer in Berthe.
What is needed is the name of the column associated with the softdelete.
If this is not specified, a normal delete will be performed.
