### PR TITLE
Adding a new function `dateToTimeZone` to AbstractBuilder

### DIFF
--- a/src/Berthe/AbstractBuilder.php
+++ b/src/Berthe/AbstractBuilder.php
@@ -1,24 +1,24 @@
 <?php
 namespace Berthe;
 
-use DateTime;
-use DateTimeZone;
+use \DateTime;
+use \DateTimeZone;
 
 abstract class AbstractBuilder implements Builder {
 
-	/**
-	 * @var the timezone to which the date will be transformed
-	 */ 
-	private $timeZone = 'Europe/Paris';
+    /**
+     * @var the timezone to which the date will be transformed
+     */ 
+    private $timeZone = 'Europe/Paris';
 
-	/**
-	 * Set the timezone
-	 * 
-	 * @param the time zone to which the date will be transformed.
-	 */
-	public function setTimeZone($timeZone) {
-		$this->timeZone = $timeZone;
-	}
+    /**
+     * Set the timezone
+     * 
+     * @param the time zone to which the date will be transformed.
+     */
+    public function setTimeZone($timeZone) {
+        $this->timeZone = $timeZone;
+    }
 
     /**
      * Transform a date string into a DateTime object using GMT timezone


### PR DESCRIPTION
The function convert a a string into a proper date object, whith the specified timeZone for the builder.
By default, its GMT+2 (Europe/Paris) time.

This is justified by the fact that the timeZone is not usually saved in DB so we need to specify a default one
