### PR TITLE
moved getDatetimeFields out of the property loop

### DIFF
--- a/src/Berthe/AbstractVO.php
+++ b/src/Berthe/AbstractVO.php
@@ -74,9 +74,10 @@ abstract class AbstractVO implements VO
 
     protected function setProperties($properties)
     {
+        $datetimeFields = $this->getDatetimeFields();
         foreach ($properties as $key => $value) {
             if (property_exists($this, $key)) {
-                if (in_array($key, $this->getDatetimeFields())) {
+                if (in_array($key, $datetimeFields)) {
                     $this->{$key} = DateTimeConverter::convert($value);
                 } else {
                     $this->{$key} = $value;


### PR DESCRIPTION
Imagine QuoteObject, fetched from API
Let's say 25 objects fetched, 100 fields to loop on... 2500 calls to that getter for free -_-

But in the API, we fetch a few more objects using embeds, right ? :)