### PR TITLE
Fix error message

### DIFF
--- a/src/Berthe/DAL/MongoDbAdapter.php
+++ b/src/Berthe/DAL/MongoDbAdapter.php
@@ -74,7 +74,7 @@ class MongoDbAdapter extends \Zend_Db_Adapter_Abstract
         }
         if (!isset($config['options'])) {
             throw new \InvalidArgumentException(
-                "Configuration array must have a key for 'port'"
+                "Configuration array must have a key for 'options'"
             );
         }
     }


### PR DESCRIPTION
Fix du message d'erreur dans le MongoAdapter.
Par ailleurs, l'implémentation actuelle force à fournir un tableau d'options qui n'est pas demandé par MongoClient. Je trouve ça dommage.
Je trouve dommage aussi de passer par un tableau dans le constructeur alors qu'il n'y a que 3 paramètres, dont un normalement optionnel. 