### PR TITLE
Handle OR operator for MongoDB

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+![Status](https://img.shields.io/badge/status-in%20development-orange.svg)
+<!--![Status](https://img.shields.io/badge/status-hold-red.svg)-->
+<!--![Status](https://img.shields.io/badge/status-ready-green.svg)-->
+----------------------------------------------------------------------------
+
+## Description
+A few sentences describing the overall goals of the pull request's commits.
+
+
+## Todos
+- [ ] Tests
+- [ ] Documentation
+
+
+## Deploy Notes
+Notes regarding deployment the contained body of work.
+These should note any db migrations, etc.
+
+- [ ] SQL migration
+- [ ] AMQP declarations
+- [ ] Infrastructure modification
+
+
+## Impacted Areas in Application
+List general components of the application that this PR will affect:
+* 


### PR DESCRIPTION
![Status](https://img.shields.io/badge/status-ready-green.svg)
----------------------------------------------------------------------------

## Description
Fixes #75
-> This induces a *breaking change* because all previous calls to the Mongo query builder with an OR operator behaved like if it was an AND operator.

## Todos
- [x] Add Github PR template (copy from `evaneos-ng`)
- [x] Handle OR operator in `FetcherMongoQueryBuilder`

## Deploy Notes
- [x] Update `composer.json` of `evaneos/picsou` and draft a release
- [x] Update `composer.json` of `evaneos/minitel` and draft a release
- [x] Update `composer.json` of `evaneos/EVFramework` and draft a release
- Update dependency version in APIv2

## Impacted Areas in evaneos-ng
* APIv2
* Pro / Redac / Facets
