### PR TITLE
Do not bind parameters when fetcher decides to remove the WHERE clause

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+```shell
+# Install dependencies
+make install
+
+# Run tests
+make run-tests
+```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: run-tests
+run-tests:
+	docker run --rm -ti -v $(PWD):/app --workdir /app php:7.4-cli vendor/bin/phpunit test/
+
+.PHONY: install
+install:
+	docker run -ti --rm \
+        --env COMPOSER_HOME=/tmp/composer \
+        --volume ${HOME}/.config/composer:/tmp/composer \
+        --volume ${PWD}:/app \
+        --user $(id -u):$(id -g) \
+        --workdir /app \
+        composer:1 composer install

--- a/src/Berthe/DAL/FetcherPGSQLQueryBuilder.php
+++ b/src/Berthe/DAL/FetcherPGSQLQueryBuilder.php
@@ -42,8 +42,10 @@ class FetcherPGSQLQueryBuilder implements FetcherQueryBuilder
         list($filterInReq, $filterToParameter) = $this->buildOperation($fetcher);
         if ($fetcher->hasEmptyIN()) {
             $filterInReq = '1=2';
+            $filterToParameter = [];
         } elseif ($filterInReq == '' || $filterInReq == '()') {
             $filterInReq = '1=1';
+            $filterToParameter = [];
         }
         return array($filterInReq, $filterToParameter);
     }

--- a/test/src/DAL/FetcherPGSQLQueryBuilderTest.php
+++ b/test/src/DAL/FetcherPGSQLQueryBuilderTest.php
@@ -46,7 +46,7 @@ class FetcherPGSQLQueryBuilderTest extends PHPUnit_Framework_TestCase
         list($query, $params) = (new FetcherPGSQLQueryBuilder())->buildFilters($fetcher);
 
         self::assertEquals('1=2', $query);
-        self::assertEquals([6543], $params);
+        self::assertEmpty($params);
     }
 
     /** @test */

--- a/test/src/DAL/FetcherPGSQLQueryBuilderTest.php
+++ b/test/src/DAL/FetcherPGSQLQueryBuilderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Berthe\DAL\FetcherPGSQLQueryBuilder;
+use Berthe\Fetcher;
+
+class FakeFetcher extends Fetcher
+{
+    public function filterByIds(array $ids)
+    {
+        $this->addFilter('id', Fetcher::TYPE_IN, $ids);
+        return $this;
+    }
+
+    public function filterByThingyId($id)
+    {
+        $this->addFilter('thingy_id', Fetcher::TYPE_EQ, $id);
+        return $this;
+    }
+}
+
+class FetcherPGSQLQueryBuilderTest extends PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_builds_query_with_in_filter_and_id_filter()
+    {
+        $fetcher = (new FakeFetcher())
+            ->filterByIds([1, 2, 3])
+            ->filterByThingyId(6543);
+
+        list($query, $params) = (new FetcherPGSQLQueryBuilder())->buildFilters($fetcher);
+
+        self::assertEquals(
+            '((((id  = ? ) OR (id  = ? ) OR (id  = ? ))) AND (thingy_id  = ? ))',
+            $query
+        );
+        self::assertEquals([1, 2, 3, 6543], $params);
+    }
+
+    /** @test */
+    public function it_builds_query_with_empty_in_filter_and_id_filter()
+    {
+        $fetcher = (new FakeFetcher())
+            ->filterByIds([])
+            ->filterByThingyId(6543);
+
+        list($query, $params) = (new FetcherPGSQLQueryBuilder())->buildFilters($fetcher);
+
+        self::assertEquals('1=2', $query);
+        self::assertEquals([6543], $params);
+    }
+
+    /** @test */
+    public function it_builds_inclusive_query_without_filters()
+    {
+        list($query, $params) = (new FetcherPGSQLQueryBuilder())
+            ->buildFilters(new FakeFetcher());
+
+        self::assertEquals('1=1', $query);
+        self::assertEmpty($params);
+    }
+}


### PR DESCRIPTION
![Status](https://img.shields.io/badge/status-ready-green.svg)
----------------------------------------------------------------------------

## Description

On ne bind aucun paramètre lorsque le fetcher les retire dans la clause `WHERE`.

## Origine

Lors de la migration d'APIv2 de PHP 5.5 à PHP 7.4, on a remarqué ce genre d'erreur :

```
1/2 SQLSTATE[08P01]: <<Unknown error>>: 7 ERROR:  bind message supplies 1 parameters,
but prepared statement "pdo_stmt_0000002c" requires 0, query was: [...]
```
<details><summary>Exemple de requête SQL :</summary><p>

```sql
SELECT
    DISTINCT (lastsub.id) AS id
FROM
    (
    SELECT
        sub.*
    FROM
        (SELECT p.id, la.localagency_id as localagency_id FROM phoning.phonecall p LEFT JOIN quotes_has_phonecalls qhph ON (qhph.phonecall_id = p.id)  LEFT JOIN quotes q ON (q.id = qhph.quote_id)  LEFT JOIN localagents la ON (q.localagent_id = la.id) )  AS sub
    WHERE
        1=2
    ) AS lastsub
ORDER BY
    id ASC
```

</p></details>

Lorsqu'on ajoute un `filter` de type `IN` sans valeur, le fetcher décide d'invalider la clause `WHERE` avec `1=2`. Sauf qu'il ne vide pas les bind parameters qui sont à présent inutiles des autres filtres et PostgreSQL n'apprécie pas.

On soupçonne, sans pouvoir le vérifier dans le [code source de PDO](https://github.com/php/php-src/blob/php-5.5.38/ext/pdo/pdo_stmt.c), un changement de comportement de PDO qui, en PHP 5.5, prenat le partie de ne pas déclarer de _bind parameters_ s'il n'en avait aucun dans le _statement_.

## Todos

- [x] ajouter un peu de paillettes à la contribution :sparkles:
- [x] ajouter un test sur les filtres
- [x] corriger le comportement de _bind parameters_

## Deploy Notes

_N/A_